### PR TITLE
Override existing options with provided options

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ class VueLoaderOptionPlugin {
         }
 
         module.loaders.forEach(l => {
-          if (l.loader.indexOf(loaderOption.loader) >= 0 && !l.options) {
+          if (l.loader.indexOf(loaderOption.loader) >= 0) {
             if (loaderOption.options.toContext) {
               context[loaderOption.loaderName] = loaderOption.options
             } else {


### PR DESCRIPTION
In some circumstances, options might already be set by some tool, but
options provided via this plugin should overrule existing options.

Fixes #1